### PR TITLE
Move Dependencies and Update Error Handling

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -77,7 +77,7 @@
             var validation = schema.composer.app.validate(config),
                 appConfig;
             if (validation.error) {
-                throw (validation.error);
+                throw validation.error;
             }
             appConfig = validation.value;
             return self.composeAppSync(appConfig);
@@ -362,7 +362,7 @@
                     promises = [];
 
                 if (validation.error) {
-                    return resolve(validation.error);
+                    return reject(validation.error);
                 }
                 routeConfig = validation.value;
 

--- a/lib/conductor.js
+++ b/lib/conductor.js
@@ -11,7 +11,7 @@
  * @module express-composer
  */
 
-(function (module, exports, express) {
+(function (module, exports) {
     "use strict";
     var express = require('express'),
         mixin = require('utils-merge'),

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -12,10 +12,8 @@
         util = require('util');
 
     function HeadersSent () {
-    };
+    }
 
-    var noop = function () {
-    };
     module.exports = {
         /**
          * Creates an express middle ware handler that will iterate through composers handlers
@@ -40,18 +38,16 @@
                             if (handler.name && result !== undefined && !res.headersSent) {
                                 scope.addResult(handler.name, result)
                             }
-                        })
+                        });
                 }).then(function () {
                     if (!res.headersSent) {
                         next();
                     }
-                })
-                    .catch(HeadersSent, noop)
-                    .catch(function (err) {
+                }).catch(function (err) {
                         if (!res.headersSent) {
                             next(err);
                         }
-                    })
+                    });
             };
         },
         /**
@@ -65,7 +61,7 @@
             return function composerErrorHandler (err, req, res, next) {
                 var scope = req.expressComposerScopeCache.get(scopeProvider.key);
 
-                return Promise.each(handlers, function (handler) {
+                Promise.each(handlers, function (handler) {
                     if (res.headersSent) {
                         return Promise.reject(new HeadersSent());
                     }
@@ -77,14 +73,17 @@
                             if (handler.name && result !== undefined && !res.headersSent) {
                                 scope.addError(handler.name, result)
                             }
-                        }, noop)
+                        })
 
                 }).then(function () {
                     if (!res.headersSent) {
                         next(err);
                     }
-                })
-                    .catch(HeadersSent, noop)
+                }).catch(function (err) {
+                    if (!res.headersSent) {
+                        next(err);
+                    }
+                });
             };
         },
         /**

--- a/lib/scopeProvider.js
+++ b/lib/scopeProvider.js
@@ -51,13 +51,13 @@
             scopePropertiesPromise.then(function (result) {
                 cacheStore.set(self.key, parentScope ? parentScope.new(result) : new Scope(result));
                 next();
-            }, next)
+            }, next);
         }
     }
 
     function getCacheStore (req) {
         return req.expressComposerScopeCache ? req.expressComposerScopeCache : req.expressComposerScopeCache = new Cache();
-    };
+    }
 
     /**
      * Scope object used during handler execution
@@ -202,7 +202,7 @@
                 Object.defineProperty(this, 'parent', {
                     value: parent
                 });
-            }
+            };
             this._new.prototype = this;
         }
         return new this._new(arg, this);
@@ -217,6 +217,6 @@
         this.get = function (key) {
             return cache[key]
         };
-    };
+    }
 
 }(module, require));

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "jshint-stylish": "^2.0.1",
     "mocha": "^2.3.3",
     "run-sequence": "^1.1.4",
+    "supertest": "^1.1.0",
     "supertest-as-promised": "^2.0.2"
   },
   "peerDependencies": {
@@ -57,7 +58,6 @@
     "joi": "^6.9.0",
     "methods": "^1.1.1",
     "node-uuid": "^1.4.3",
-    "supertest": "^1.1.0",
     "utils-merge": "^1.0.0",
     "vhost": "^3.0.1"
   }


### PR DESCRIPTION
This PR moves `supertest` to `devDependencies` as it is not a direct dependency. It also fixes a few syntax issues that were found. Lastly, it updates the error handling going on around handlers so that errors are no longer swallowed in some cases. There's still an outlying case though where if a handler sends a response then returns a rejected promise from the handler the error will be swallowed.
